### PR TITLE
Fix wrong setting for previous node in dlist.rs

### DIFF
--- a/src/ch6/dlist/src/dlist.rs
+++ b/src/ch6/dlist/src/dlist.rs
@@ -46,7 +46,7 @@ impl List {
             },
             Some(old_head) => {
                 old_head.borrow_mut().prev = 
-                    Some(Rc::downgrade(&old_head));
+                    Some(Rc::downgrade(&n));
                 n.borrow_mut().next = Some(old_head);
                 self.head = Some(n);
             }


### PR DESCRIPTION
When inserting new node at head, current code sets the prev pointer of the second to itself. So it should generate infinite-loop if somebody reads the list reversely.

This patch changes unshift() function to set the prev pointer of the second node to the first node.

I'm attaching a test code below. Before fix, it went into the infinite-loop. After fix, it can print values in the list in reverse order.

fn main() {
    let mut list = List::new();

    list.push(100);
    list.push(110);

    list.unshift(10);
    list.unshift(20);

    let mut ll = list.foot;

    loop {
        match ll.take() {
            None => break,
            Some(cur) => {
                let cb = cur.borrow();
                println!("{}", cb.data);
                match &cb.prev {
                    None => ll = None,
                    Some(prev) => {
                        ll = prev.upgrade();
                    }
                }
            }
        }
    }
}